### PR TITLE
Fix version format

### DIFF
--- a/cl-svg.asd
+++ b/cl-svg.asd
@@ -30,7 +30,7 @@
 (defsystem :cl-svg
   :name "CL-SVG"
   :author "William S. Annis <wm.annis@gmail.com>"
-  :version "0.03"
+  :version "0.0.3"
   :maintainer "William S. Annis <wm.annis@gmail.com>"
   :licence "MIT License"
   :description "Produce Scalable Vector Graphics (SVG) files"


### PR DESCRIPTION
I've packed this system assuming version should be `0.0.3` instead of `0.03` but ASDF troughs warnins during `(asdf:load-system :cl-svg)`
```
WARNING: PARSE-VERSION: "0.03" contains leading zeros
WARNING: Invalid :version specifier "0.03" for component "cl-svg" from file #P"/gnu/store/dd6bnkgpdyh16cw25m4nasxmc4g5yifl-sbcl-cl-svg-0.0.3-1.1e988eb/share/common-lisp/sbcl/cl-svg/cl-svg.asd", using NIL instead
```