### PR TITLE
Rename version from 0.03 to 0.3

### DIFF
--- a/cl-svg.asd
+++ b/cl-svg.asd
@@ -30,7 +30,7 @@
 (defsystem :cl-svg
   :name "CL-SVG"
   :author "William S. Annis <wm.annis@gmail.com>"
-  :version "0.03"
+  :version "0.3"
   :maintainer "William S. Annis <wm.annis@gmail.com>"
   :licence "MIT License"
   :description "Produce Scalable Vector Graphics (SVG) files"


### PR DESCRIPTION
Loading cl-svg via `(require :cl-svg)` signals two warnings:
```
WARNING: PARSE-VERSION: "0.03" contains leading zeros
WARNING: Invalid :version specifier "0.03" for component "cl-svg" from file #P"/path/to/cl-svg-20180228-git/cl-svg.asd", using NIL instead
```
According to the [ASDF manual](https://common-lisp.net/project/asdf/asdf.html#Version-specifiers-1), 
canonical version specifiers are period-separated numbers with no leading
zeroes. Fixing the version to "0.3" conforms to the spec and resolves the
warning.