### PR TITLE
Removed leading zeros from ASDF version component

### DIFF
--- a/cl-svg.asd
+++ b/cl-svg.asd
@@ -30,7 +30,7 @@
 (defsystem :cl-svg
   :name "CL-SVG"
   :author "William S. Annis <wm.annis@gmail.com>"
-  :version "0.03"
+  :version "0.3"
   :maintainer "William S. Annis <wm.annis@gmail.com>"
   :licence "MIT License"
   :description "Produce Scalable Vector Graphics (SVG) files"
@@ -40,4 +40,3 @@
                (:file "path")
                (:file "svg"))
   :serial t)
-  


### PR DESCRIPTION
Fix for Issue #17 : ASDF complains about leading zeros in version number components.